### PR TITLE
RFC4648 compliant base64 encoder/decoder

### DIFF
--- a/src/pages/base64.tsx
+++ b/src/pages/base64.tsx
@@ -21,7 +21,7 @@ export default function Base64Page() {
     setDecoded(value)
     clearErrors()
     try {
-      const result = window.btoa(value)
+      const result = btoa(unescape(encodeURIComponent(value)))
       setEncoded(result)
     } catch (err) {
       console.error(err)
@@ -34,7 +34,7 @@ export default function Base64Page() {
     setEncoded(value)
     clearErrors()
     try {
-      const result = window.atob(value)
+      const result = decodeURIComponent(escape(atob(value)))
       setDecoded(result)
     } catch (err) {
       console.error(err)


### PR DESCRIPTION
This PR makes the base64 encoder/decoder [RFC4648](https://tools.ietf.org/html/rfc4648#section-4) compliant which can handle UTF-8 correctly. 